### PR TITLE
feat: add Gitcoin Passport requirements alert to request form

### DIFF
--- a/src/components/RequestForm/index.tsx
+++ b/src/components/RequestForm/index.tsx
@@ -258,6 +258,32 @@ const RequestForm = ({
                     <div className="space-y-6">
                         {renderAlert()}
 
+                        <Alert className="bg-blue-500/10 text-blue-600 border-blue-200">
+                            <Info
+                                className="h-5 w-5 mt-0.5"
+                                aria-hidden="true"
+                            />
+                            <AlertDescription className="text-blue-600/80">
+                                To request funds, you need a Gitcoin Passport
+                                score of at least 2 or to have made a donation
+                                of at least 2 ETH on any network.
+                            </AlertDescription>
+                            <div className="mt-4 flex gap-2">
+                                <Button variant="outline" size="sm" asChild>
+                                    <a
+                                        href="https://passport.gitcoin.co/"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        Learn more about Passport
+                                    </a>
+                                </Button>
+                                <Button variant="outline" size="sm" asChild>
+                                    <a href="?tab=donate">Donate now</a>
+                                </Button>
+                            </div>
+                        </Alert>
+
                         <div className="space-y-4">
                             <div className="space-y-2">
                                 <div className="relative">


### PR DESCRIPTION
### Description
This PR is to add an informational alert that explains the prerequisites for using the faucet:
- Gitcoin Passport score of at least 2, or
- Donation of at least 2 ETH on any network

The alert includes links to learn more about Gitcoin Passport and to switch to the donate tab.

### Issues

Closes #5 

### Changes

- Add Alert to display Pre requisites

### Manual Testing & Verification


**Screenshots or Link to the screen recording:**
<img width="813" alt="Screenshot 2025-06-13 at 07 10 24" src="https://github.com/user-attachments/assets/f6996cd8-0817-4f28-a497-f5ce1c4f0614" />

### Checklist:

- [ ] Code follows the style guidelines of this project
- [ ] Code is well commented, particularly in hard-to-understand areas
- [ ] Corresponding changes have been made to the documentation
- [ ] Code changes generate no new warnings
- [ ] Changes have been manually tested and/or a screen recording has been included.
