### PR TITLE
refactor: optimise balance/network check

### DIFF
--- a/src/app/api/donate/route.ts
+++ b/src/app/api/donate/route.ts
@@ -9,7 +9,7 @@ import { donationZodSchema } from "@/lib/db/models/donation";
 import { z } from "zod";
 import { Address, checksumAddress, formatUnits, Hex, getAddress } from "viem";
 import {
-    filterWorkingRPCs,
+    getETHBalance,
     getNetworkInfo,
     getTransaction,
     isMatchingAddress,
@@ -72,7 +72,10 @@ export const POST = async (req: NextRequest) =>
             }
 
             // filter working RPCs
-            const workingRPCURLs = await filterWorkingRPCs(networkDetails.rpc);
+            const { urls: workingRPCURLs } = await getETHBalance(
+                env.FAUCET_ADDRESS as `0x${string}`,
+                networkDetails.rpc
+            );
             if (workingRPCURLs.length === 0) {
                 return error(
                     `Network connectivity issue with ${networkDetails.name}. We're unable to verify your transaction at this time. Please try again later.${contactSupportMessage}`,

--- a/src/app/api/donate/route.ts
+++ b/src/app/api/donate/route.ts
@@ -74,7 +74,9 @@ export const POST = async (req: NextRequest) =>
             // filter working RPCs
             const { urls: workingRPCURLs } = await getETHBalance(
                 env.FAUCET_ADDRESS as `0x${string}`,
-                networkDetails.rpc
+                networkDetails.rpc,
+                undefined,
+                true
             );
             if (workingRPCURLs.length === 0) {
                 return error(

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -17,7 +17,9 @@ export async function GET() {
 
             const { urls: workingRPCs } = await getETHBalance(
                 env.FAUCET_ADDRESS as `0x${string}`,
-                networkDetails.rpc
+                networkDetails.rpc,
+                undefined,
+                true
             );
             if (workingRPCs.length === 0) {
                 status = HealthCheckStatus.Degraded;

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,7 +1,8 @@
 import { success, error } from "@/lib/api/response";
 import { HealthCheckResponse, HealthCheckStatus } from "@/lib/api/types";
-import { filterWorkingRPCs, getNetworkInfo } from "@/lib/networks";
+import { getETHBalance, getNetworkInfo } from "@/lib/networks";
 import { withDB } from "@/lib/db/with-db";
+import { env } from "@/config/env";
 
 export async function GET() {
     return withDB(async () => {
@@ -14,7 +15,10 @@ export async function GET() {
                 status = HealthCheckStatus.Degraded;
             }
 
-            const workingRPCs = await filterWorkingRPCs(networkDetails.rpc);
+            const { urls: workingRPCs } = await getETHBalance(
+                env.FAUCET_ADDRESS as `0x${string}`,
+                networkDetails.rpc
+            );
             if (workingRPCs.length === 0) {
                 status = HealthCheckStatus.Degraded;
             }

--- a/src/app/api/state/route.ts
+++ b/src/app/api/state/route.ts
@@ -3,7 +3,6 @@ import { error, success, validateQueryParams } from "@/lib/api/response";
 import { NetworkFaucetState } from "@/lib/api/types";
 import { calculateDailyClaimAmount } from "@/lib/faucet";
 import { getETHBalance, getNetworkInfo } from "@/lib/networks";
-import { filterWorkingRPCs } from "@/lib/networks";
 import { NextRequest } from "next/server";
 import { Address } from "viem";
 import { z } from "zod";
@@ -32,16 +31,10 @@ export async function GET(req: NextRequest) {
             return error("No RPC URLs found for network", 400);
         }
 
-        // Get working RPCs
-        const workingRPCURLs = await filterWorkingRPCs(networkDetails.rpc);
-        if (workingRPCURLs.length === 0) {
-            return error("No working RPC URLs found for network", 400);
-        }
-
         // Get faucet balance
-        const faucetBalance = await getETHBalance(
+        const { balance: faucetBalance } = await getETHBalance(
             env.FAUCET_ADDRESS as Address,
-            workingRPCURLs
+            networkDetails.rpc
         );
 
         // Calculate daily claim amount

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -89,7 +89,7 @@ export const env = {
     NEXT_PUBLIC_MAX_ALLOWED_BALANCE: getEnvValue(
         "NEXT_PUBLIC_MAX_ALLOWED_BALANCE",
         process.env.NEXT_PUBLIC_MAX_ALLOWED_BALANCE,
-        true,
+        false, //set required to false since there's a default value
         "2"
     ),
 };

--- a/src/lib/cache/networkBalances.ts
+++ b/src/lib/cache/networkBalances.ts
@@ -55,7 +55,7 @@ export const getNetworkBalance = async (
 
     try {
         // Fetch the balance
-        const balance = await getETHBalance(
+        const { balance } = await getETHBalance(
             env.FAUCET_ADDRESS as Address,
             rpcUrls,
             decimals

--- a/src/lib/hooks/useNetworkBalances.ts
+++ b/src/lib/hooks/useNetworkBalances.ts
@@ -41,11 +41,12 @@ export const useNetworkBalances = (networks: INetwork[]) => {
                 queryKey: ["networkBalance", network.chainId],
                 queryFn: async () => {
                     try {
-                        return await getETHBalance(
+                        const { balance } = await getETHBalance(
                             env.FAUCET_ADDRESS as Address,
                             network.rpc,
                             network.nativeCurrency?.decimals || 18
                         );
+                        return balance;
                     } catch (error) {
                         console.debug(
                             `Error prefetching balance for network ${network.name}:`,
@@ -74,11 +75,16 @@ export const useNetworkBalances = (networks: INetwork[]) => {
         queries: networks.map((network) => ({
             queryKey: ["networkBalance", network.chainId],
             queryFn: async () => {
-                return await getETHBalance(
-                    env.FAUCET_ADDRESS as Address,
-                    network.rpc,
-                    network.nativeCurrency?.decimals || 18
-                );
+                try {
+                    const { balance } = await getETHBalance(
+                        env.FAUCET_ADDRESS as Address,
+                        network.rpc,
+                        network.nativeCurrency?.decimals || 18
+                    );
+                    return balance;
+                } catch (error) {
+                    console.log("networkQuery failed", error);
+                }
             },
             staleTime: Infinity, // Never consider data stale
             gcTime: 24 * 60 * 60 * 1000, // Keep in cache for 24 hours

--- a/src/lib/retry/index.ts
+++ b/src/lib/retry/index.ts
@@ -1,6 +1,6 @@
 // Configuration constants
 const CONFIG = {
-    MAX_RETRIES: 3,
+    MAX_RETRIES: 2,
     RETRY_DELAY: 1000, // milliseconds
 } as const;
 


### PR DESCRIPTION
### Description
Optimised the balance/network check by removing redundant `eth_blockNumber` fetching by the _testRPCEndpoint/filterWorkingRPCs_ duo. Since the cost of obtaining the blockNumber and the balance is the same (1 RPC call), and the availability of a node can be confirmed using either of the requests, we could simply do without fetching the blockNumber, as it's completely useless for our use case.A single trip to the node to get the balance can also be 

### Issues

<!-- List issues addesses by the code change. Prefix issue with "Closes" if the issue is resolved. e.g: "Closes #15" -->
<!-- That will automatically close the issue when this PR has been merged. -->

### Changes

<!-- Short list of code changes in this -->

### Manual Testing & Verification

**If applicable, please provide screenshot(s) or screen recording(s) of your changes in action to demonstrate that they work as expected and that no existing functionality is broken.**

You can use a free tool like [Loom](https://www.loom.com/) or [Streamable](https://streamable.com/) to record your screen.

**Screenshots or Link to the screen recording:**

[Please Attach screenshots or paste a link to your screen recording here]

### Checklist:

- [ ] Code follows the style guidelines of this project
- [ ] Code is well commented, particularly in hard-to-understand areas
- [ ] Corresponding changes have been made to the documentation
- [ ] Code changes generate no new warnings
- [ ] Changes have been manually tested and/or a screen recording has been included.
